### PR TITLE
Add DashLoader support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,12 @@ repositories {
             includeGroup "curse.maven"
         }
     }
+	maven {
+		url "https://oskarstrom.net/maven"
+		content {
+			includeGroup "net.oskarstrom"
+		}
+	}
 	maven { url "https://maven.shedaniel.me/" }
 }
 
@@ -50,11 +56,11 @@ dependencies {
 
 	modCompileOnly "me.shedaniel:RoughlyEnoughItems-api-fabric:6.0.247-alpha"
 
-	modImplementation("net.devtech:Stacc:1.2.1") { transitive = false }
+	modImplementation("net.devtech:Stacc:1.2.3") { transitive = false }
 	include "net.devtech:Stacc:1.2.1"
 
 	include "curse.maven:xlpackets-390168:3022566" // Avoid Stupid Networking Error AHHHHHHHHHHHHHHHH
-
+	modImplementation 'net.oskarstrom:DashLoader:2.0'
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,12 @@
 org.gradle.jvmargs=-Xmx1G
 
 # https://modmuss50.me/fabric.html
-minecraft_version=1.17-pre1
-yarn_mappings=1.17-pre1+build.1
-loader_version=0.11.3
+minecraft_version=1.17
+yarn_mappings=1.17+build.13
+loader_version=0.11.6
 
 #Fabric api
-fabric_version=0.34.8+1.17
+fabric_version=0.36.0+1.17
 
 # Mod Properties
 	mod_version = 2.5.1

--- a/src/main/java/io/github/coolmineman/bitsandchisels/dashloader/DashBitItemModel.java
+++ b/src/main/java/io/github/coolmineman/bitsandchisels/dashloader/DashBitItemModel.java
@@ -1,0 +1,28 @@
+package io.github.coolmineman.bitsandchisels.dashloader;
+
+import io.github.coolmineman.bitsandchisels.BitItemModel;
+import net.minecraft.client.render.model.BakedModel;
+import net.oskarstrom.dashloader.DashRegistry;
+import net.oskarstrom.dashloader.api.annotation.DashConstructor;
+import net.oskarstrom.dashloader.api.annotation.DashObject;
+import net.oskarstrom.dashloader.api.enums.ConstructorMode;
+import net.oskarstrom.dashloader.model.DashModel;
+
+@DashObject(BitItemModel.class)
+public class DashBitItemModel implements DashModel {
+
+    @DashConstructor(ConstructorMode.EMPTY)
+    public DashBitItemModel() {
+    }
+
+    @Override
+    public BakedModel toUndash(DashRegistry registry) {
+        return new BitItemModel();
+    }
+
+
+    @Override
+    public int getStage() {
+        return 0;
+    }
+}

--- a/src/main/java/io/github/coolmineman/bitsandchisels/dashloader/DashBitsBlockModel.java
+++ b/src/main/java/io/github/coolmineman/bitsandchisels/dashloader/DashBitsBlockModel.java
@@ -1,0 +1,26 @@
+package io.github.coolmineman.bitsandchisels.dashloader;
+
+import io.github.coolmineman.bitsandchisels.BitsBlockModel;
+import net.oskarstrom.dashloader.DashRegistry;
+import net.oskarstrom.dashloader.api.annotation.DashConstructor;
+import net.oskarstrom.dashloader.api.annotation.DashObject;
+import net.oskarstrom.dashloader.api.enums.ConstructorMode;
+import net.oskarstrom.dashloader.model.DashModel;
+
+@DashObject(BitsBlockModel.class)
+public class DashBitsBlockModel implements DashModel {
+
+    @DashConstructor(ConstructorMode.EMPTY)
+    public DashBitsBlockModel() {
+    }
+
+    @Override
+    public BitsBlockModel toUndash(DashRegistry registry) {
+        return new BitsBlockModel();
+    }
+
+    @Override
+    public int getStage() {
+        return 0;
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -2,7 +2,6 @@
   "schemaVersion": 1,
   "id": "bitsandchisels",
   "version": "${version}",
-
   "name": "BitsAndChisels",
   "description": "Turn Blocks Into Small Bits With Chisels; Build All The Things",
   "authors": [
@@ -12,10 +11,8 @@
     "homepage": "https://github.com/CoolMineman/BitsAndChisels",
     "sources": "https://github.com/CoolMineman/BitsAndChisels"
   },
-
   "license": "CC0-1.0",
   "icon": "assets/bitsandchisels/icon.png",
-
   "environment": "*",
   "entrypoints": {
     "main": [
@@ -31,7 +28,12 @@
   "mixins": [
     "bitsandchisels.mixins.json"
   ],
-
+  "custom": {
+    "dashloader:customobject": [
+      "io.github.coolmineman.bitsandchisels.dashloader.DashBitsBlockModel",
+      "io.github.coolmineman.bitsandchisels.dashloader.DashBitItemModel"
+    ]
+  },
   "depends": {
     "fabricloader": ">=0.7.4",
     "fabric": "*",


### PR DESCRIPTION
This adds DashLoader support through our API. No changes to general code. Only build.gradle, Some dependency change just so it compiles in 1.17