### PR TITLE
Respect Flan land claims

### DIFF
--- a/buildscript/src/main/java/Buildscript.java
+++ b/buildscript/src/main/java/Buildscript.java
@@ -52,6 +52,8 @@ public class Buildscript extends FabricProject {
         d.addMaven("https://maven.shedaniel.me/", new MavenId("me.shedaniel:RoughlyEnoughItems-api-fabric:6.0.247-alpha"), ModDependencyFlag.COMPILE);
         d.addMaven("https://maven.vram.io", new MavenId("io.vram:frex-fabric-mc117:6.0.46"), ModDependencyFlag.COMPILE);
         d.addMaven("https://oskarstrom.net/maven", new MavenId("net.oskarstrom:DashLoader:2.0"), ModDependencyFlag.COMPILE);
+        d.addMaven("https://gitlab.com/api/v4/projects/21830712/packages/maven", new MavenId("io.github.flemmli97", "flan", "1.18-1.6.6:fabric-api"), ModDependencyFlag.COMPILE);
+        d.addMaven("https://gitlab.com/api/v4/projects/21830712/packages/maven", new MavenId("io.github.flemmli97", "flan", "1.18-1.6.6:fabric"), ModDependencyFlag.RUNTIME);
     }
 
     @Override

--- a/src/main/java/io/github/coolmineman/bitsandchisels/BitItem.java
+++ b/src/main/java/io/github/coolmineman/bitsandchisels/BitItem.java
@@ -71,6 +71,9 @@ public class BitItem extends Item implements ServerPlayNetworking.PlayChannelHan
                     for (int j = y1; j <= y2; j++) {
                         for (int k = z1; k <= z2; k++) {
                             mut.set(pos.getX() + Math.floorDiv(i, 16), pos.getY() + Math.floorDiv(j, 16), pos.getZ() + Math.floorDiv(k, 16));
+                            if (!BitsAndChisels.landClaimProvider.canPlace(player, mut)) {
+                                continue;
+                            }
                             int x = Math.floorMod(i, 16);
                             int y = Math.floorMod(j, 16);
                             int z = Math.floorMod(k, 16);

--- a/src/main/java/io/github/coolmineman/bitsandchisels/BitsAndChisels.java
+++ b/src/main/java/io/github/coolmineman/bitsandchisels/BitsAndChisels.java
@@ -1,5 +1,6 @@
 package io.github.coolmineman.bitsandchisels;
 
+import io.github.coolmineman.bitsandchisels.claim.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -43,6 +44,8 @@ public class BitsAndChisels implements ModInitializer {
 
 	public static final BitItem BIT_ITEM = new BitItem(new Item.Settings().maxCount(1_000_000_000));
 
+	public static LandClaimProvider landClaimProvider = new DummyLandClaimProvider();
+
 	//Hack around "Cannot reference a field before it is defined"
 	private static ItemStack getDiamondChiselStack() {
 		return new ItemStack(DIAMOND_CHISEL);
@@ -62,6 +65,10 @@ public class BitsAndChisels implements ModInitializer {
 		Registry.register(Registry.ITEM, new Identifier(MODID, "bit_item"), BIT_ITEM);
 		Registry.register(Registry.ITEM, new Identifier(MODID, "wrench"), WRENCH_ITEM);
 		Registry.register(Registry.ITEM, new Identifier(MODID, "blueprint"), BLUEPRINT);
+
+		if (FabricLoader.getInstance().isModLoaded("flan")) {
+			landClaimProvider = new FlanLandClaimProvider();
+		}
 	}
 	
 }

--- a/src/main/java/io/github/coolmineman/bitsandchisels/api/BitUtils.java
+++ b/src/main/java/io/github/coolmineman/bitsandchisels/api/BitUtils.java
@@ -113,6 +113,9 @@ public class BitUtils {
             for (int j = y1; j <= y2; j++) {
                 for (int k = z1; k <= z2; k++) {
                     mut.set(rootPos.getX() + Math.floorDiv(i, 16), rootPos.getY() + Math.floorDiv(j, 16), rootPos.getZ() + Math.floorDiv(k, 16));
+                    if (!BitsAndChisels.landClaimProvider.canBreak(player, mut)) {
+                        continue;
+                    }
                     int x = Math.floorMod(i, 16);
                     int y = Math.floorMod(j, 16);
                     int z = Math.floorMod(k, 16);

--- a/src/main/java/io/github/coolmineman/bitsandchisels/chisel/DiamondChisel.java
+++ b/src/main/java/io/github/coolmineman/bitsandchisels/chisel/DiamondChisel.java
@@ -46,7 +46,11 @@ public class DiamondChisel extends ToolItem implements ServerPlayNetworking.Play
         server.execute(() -> {
             // Execute on the main thread
             ItemStack stack = player.getMainHandStack();
-            if (player.getBlockPos().getSquaredDistance(pos.getX(), pos.getY(), pos.getZ(), true) < 81 && stack.getItem() == BitsAndChisels.DIAMOND_CHISEL) {
+            if (
+                    BitsAndChisels.landClaimProvider.canBreak(player, pos) &&
+                            player.getBlockPos().getSquaredDistance(pos.getX(), pos.getY(), pos.getZ(), true) < 81 &&
+                            stack.getItem() == BitsAndChisels.DIAMOND_CHISEL
+            ) {
                 BitUtils.attemptBreak(player, pos, x, y, z);
             }
         });

--- a/src/main/java/io/github/coolmineman/bitsandchisels/chisel/IronChisel.java
+++ b/src/main/java/io/github/coolmineman/bitsandchisels/chisel/IronChisel.java
@@ -45,7 +45,11 @@ public class IronChisel extends ToolItem implements ServerPlayNetworking.PlayCha
         server.execute(() -> {
             // Execute on the main thread
             ItemStack stack = player.getMainHandStack();
-            if (stack.getItem() == BitsAndChisels.IRON_CHISEL && player.getBlockPos().getSquaredDistance(pos.getX(), pos.getY(), pos.getZ(), true) < 81) {
+            if (
+                    BitsAndChisels.landClaimProvider.canBreak(player, pos) &&
+                    stack.getItem() == BitsAndChisels.IRON_CHISEL &&
+                    player.getBlockPos().getSquaredDistance(pos.getX(), pos.getY(), pos.getZ(), true) < 81
+            ) {
                 BitUtils.attemptBreakRegion(player, pos, x, y, z, x + 3, y + 3, z + 3);
             }
         });

--- a/src/main/java/io/github/coolmineman/bitsandchisels/claim/DummyLandClaimProvider.java
+++ b/src/main/java/io/github/coolmineman/bitsandchisels/claim/DummyLandClaimProvider.java
@@ -1,0 +1,16 @@
+package io.github.coolmineman.bitsandchisels.claim;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.math.BlockPos;
+
+public class DummyLandClaimProvider extends LandClaimProvider {
+    @Override
+    public boolean canBreak(ServerPlayerEntity entity, BlockPos pos) {
+        return true;
+    }
+
+    @Override
+    public boolean canPlace(ServerPlayerEntity entity, BlockPos pos) {
+        return true;
+    }
+}

--- a/src/main/java/io/github/coolmineman/bitsandchisels/claim/FlanLandClaimProvider.java
+++ b/src/main/java/io/github/coolmineman/bitsandchisels/claim/FlanLandClaimProvider.java
@@ -1,0 +1,25 @@
+package io.github.coolmineman.bitsandchisels.claim;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.math.BlockPos;
+
+import io.github.flemmli97.flan.api.ClaimHandler;
+import io.github.flemmli97.flan.api.permission.ClaimPermission;
+import io.github.flemmli97.flan.api.permission.PermissionRegistry;
+
+
+public class FlanLandClaimProvider extends LandClaimProvider {
+    @Override
+    public boolean canBreak(ServerPlayerEntity entity, BlockPos pos) {
+        return checkPermission(entity, pos, PermissionRegistry.BREAK);
+    }
+
+    @Override
+    public boolean canPlace(ServerPlayerEntity entity, BlockPos pos) {
+        return checkPermission(entity, pos, PermissionRegistry.PLACE);
+    }
+
+    private boolean checkPermission(ServerPlayerEntity entity, BlockPos pos, ClaimPermission perm) {
+        return ClaimHandler.getPermissionStorage(entity.getWorld()).getForPermissionCheck(pos).canInteract(entity, perm, pos);
+    }
+}

--- a/src/main/java/io/github/coolmineman/bitsandchisels/claim/LandClaimProvider.java
+++ b/src/main/java/io/github/coolmineman/bitsandchisels/claim/LandClaimProvider.java
@@ -1,0 +1,11 @@
+package io.github.coolmineman.bitsandchisels.claim;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public abstract class LandClaimProvider {
+    public abstract boolean canBreak(ServerPlayerEntity entity, BlockPos pos);
+    public abstract boolean canPlace(ServerPlayerEntity entity, BlockPos pos);
+}


### PR DESCRIPTION
This prevents the chisels from being used on claimed blocks, and the bits from being placed in claimed areas.
Unfortunately, this currently doesn't build, because the Flan artifacts in the Maven repository have a classifier appended to their filename (_-fabric_ or _-fabric-api_) that Brachyura cannot handle, causing it to look for the hash file in the wrong location (the correct being [this](https://gitlab.com/api/v4/projects/21830712/packages/maven/io/github/flemmli97/flan/1.18-1.6.6/flan-1.18-1.6.6-fabric.jar.sha1)). I was only able to build it by manually adding the remapped Flan jars from a Gradle project as dependencies.

(Fixes #81)