### PR TITLE
un-jij FAPI

### DIFF
--- a/buildscript/src/main/java/Buildscript.java
+++ b/buildscript/src/main/java/Buildscript.java
@@ -51,7 +51,7 @@ public class Buildscript extends FabricProject {
             {"fabric-mining-level-api-v1", "2.0.2+d1027f7dd2"}
         };
         for (String[] module : fapiModules) {
-            d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", module[0], module[1]), ModDependencyFlag.RUNTIME, ModDependencyFlag.COMPILE, ModDependencyFlag.JIJ);
+            d.addMaven(FabricMaven.URL, new MavenId(FabricMaven.GROUP_ID + ".fabric-api", module[0], module[1]), ModDependencyFlag.RUNTIME, ModDependencyFlag.COMPILE);
         }
         d.addMaven("https://storage.googleapis.com/devan-maven/", new MavenId("net.devtech:Stacc:1.2.3"), ModDependencyFlag.RUNTIME, ModDependencyFlag.COMPILE, ModDependencyFlag.JIJ);
         // Compat


### PR DESCRIPTION
JiJ'ing Fabric API modules is generally a Bad Move due to them using git hashes as part of the version. It's also breaking with Bits & Chisels in the BlanketCon pack since they're not getting replaced by the Quilt versions that some mods depend on. Taking off the JIJ flag should fix it no problem!